### PR TITLE
added none+i3 case

### DIFF
--- a/pkg/papesetter/linux.go
+++ b/pkg/papesetter/linux.go
@@ -24,7 +24,7 @@ func getDesktop() DE {
 		return de.Xfce{}
 	case "KDE":
 		return de.Plasma{}
-	case "i3":
+	case "i3", "none+i3":
 		return de.I3{}
 	case "GNOME":
 		return de.Gnome{}


### PR DESCRIPTION
Allowed i3 to be recognized when  XDG_SESSION_TYPE is equal to none+i3.